### PR TITLE
Different keymaps for MacOSX and Windows/Linux

### DIFF
--- a/keymaps/comment.json
+++ b/keymaps/comment.json
@@ -1,6 +1,10 @@
 {
-    "atom-text-editor": {
+    ".platform-darwin atom-text-editor": {
         "shift-cmd-m": "comment:toggle",
         "alt-cmd-m": "comment:toggleSingleLine"
+    },
+    ".platform-win32 atom-text-editor, .platform-linux atom-text-editor": {
+        "shift-ctrl-m": "comment:toggle",
+        "alt-ctrl-m": "comment:toggleSingleLine"
     }
 }


### PR DESCRIPTION
The Cmd key is not available under Windows and Linux, so instead these platforms use the Ctrl key. Fixes issue #48